### PR TITLE
Add conversation history endpoint and display past messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,6 +102,11 @@ TOOL_FUNCS = {"write_file": write_file, "read_file": read_file, "write_command":
 @app.route("/")
 def index(): return render_template("index.html")
 
+@app.route("/api/history")
+def history():
+    """Return full conversation history."""
+    return jsonify(HISTORY)
+
 @app.route("/api/chat", methods=["POST"])
 def chat():
     data      = request.json

--- a/static/app.js
+++ b/static/app.js
@@ -1,6 +1,21 @@
 const chatPane = document.getElementById("chatPane");
 const termPane = document.getElementById("termPane");
 
+async function loadHistory(){
+  const r = await fetch("/api/history");
+  const hist = await r.json();
+  hist.forEach(m=>{
+    if(m.role === "user")
+      bubble(m.content,"user",chatPane);
+    else if(m.role === "assistant" && m.content)
+      bubble(m.content,"ai",chatPane);
+    else if(m.role === "tool")
+      bubble(`$ ${m.name}\n${m.content}`,"code",termPane);
+  });
+}
+
+loadHistory();
+
 async function post(url, body){
   const r = await fetch(url,{
       method:"POST",


### PR DESCRIPTION
## Summary
- expose new `/api/history` endpoint in `app.py`
- show previous chat history on page load via `loadHistory()` in `static/app.js`

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684dae37d0208326a04ef0f403272f16