### PR TITLE
Fix scrollbars for chat and terminal

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15,12 +15,14 @@ input,select,textarea,button{border:none;outline:none;border-radius:6px;padding:
 button{background:var(--accent);color:#000;cursor:pointer}
 button:hover{filter:brightness(1.1)}
 main{display:flex;gap:1rem;padding:1rem;height:100%}
-.pane{
-  flex:1; overflow-y:auto; padding:1rem;
-  background:rgba(255,255,255,.05); border-radius:8px;
-  scrollbar-width:none; -ms-overflow-style:none;
-}
-.pane::-webkit-scrollbar{display:none}
+  .pane{
+    flex:1; overflow-y:auto; padding:1rem;
+    background:rgba(255,255,255,.05); border-radius:8px;
+    /* allow scrollbars to appear when content overflows */
+    scrollbar-width:auto; -ms-overflow-style:auto;
+  }
+  /* show default scrollbars */
+  .pane::-webkit-scrollbar{display:block}
 .term{font-family:monospace;white-space:pre-wrap;background:#000}
 .bubble{max-width:80%;margin:.4rem 0;padding:.6rem;border-radius:8px}
 .ai   {background:rgba(56,189,248,.15)}


### PR DESCRIPTION
## Summary
- show default scrollbars on chat and terminal panes so long conversations remain usable

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684daf4064788326bde399f7f8aadf74