### PR TITLE
Add provider controls and coder precheck

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -41,9 +41,9 @@ function showPlan(planStr, round){
 
     plan.tasks.forEach(t=>{ html += `<li>[Agent ${t.agent}] ${t.desc}</li>`; });
     html += '</ul>';
-    bubble(html,'ai',chatPane,true);
+    bubble(html,'orc',chatPane,true);
     for(let i=1;i<=plan.agents;i++){
-      const wrap = bubble(`Agent ${i}: `,'ai',chatPane,true);
+      const wrap = bubble(`Agent ${i}: `,'orc',chatPane,true);
       const prog = document.createElement('progress');
       prog.id = `round${round}-agent${i}-prog`;
       prog.max = 100;
@@ -63,13 +63,21 @@ async function sendChat(){
 
   const data = await post("/api/chat",{
     prompt:  msg,
-    provider: document.getElementById("provider").value,
+    orc_provider:   document.getElementById("orcProvider").value,
+    coder_provider: document.getElementById("coderProvider").value,
     orchestrator_model: document.getElementById("orcModel").value,
     coder_model:        document.getElementById("coderModel").value,
     workers: parseInt(document.getElementById("workers").value,10)
   });
 
   (data.plans||[]).forEach((p,i)=> showPlan(p,i+1));
+  if(data.coder){
+    (data.coder.tool_runs||[]).forEach(t=>{
+      bubble(`[Coder] $ ${t.cmd}\n${t.result}`,"code",termPane);
+    });
+    if(data.coder.reply)
+      bubble(`[Coder] ${data.coder.reply}`,"ai",chatPane);
+  }
   if(data.orchestrator){
     (data.orchestrator.tool_runs||[]).forEach(t=>{
       bubble(`[Orc] $ ${t.cmd}\n${t.result}`,"code",termPane);
@@ -84,7 +92,7 @@ async function sendChat(){
     if(prog) prog.value = 100;
   });
   if(data.orchestrator && data.orchestrator.reply){
-    bubble(`[Orchestrator] ${data.orchestrator.reply}`,"ai",chatPane);
+    bubble(`[Orchestrator] ${data.orchestrator.reply}`,"orc",chatPane);
   }
 }
 document.getElementById("sendChat").onclick = sendChat;

--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,7 @@
 /* ---- global ---- */
 :root{
   --bg1:#0f172a; --bg2:#1e293b; --accent:#38bdf8;
-  --msg:#e2e8f0; --user:#f0abfc; --term:#16f75f;
+  --msg:#e2e8f0; --user:#f0abfc; --term:#16f75f; --orc:#f8e36b;
 }
 *{box-sizing:border-box}
 body{
@@ -48,6 +48,7 @@ main{
 .ai   {background:rgba(56,189,248,.15)}
 .user {align-self:flex-end;background:rgba(240,171,252,.2)}
 .code {color:var(--term)}
+.orc  {background:rgba(248,227,107,.2)}
 footer{display:grid;grid-template-columns:1fr auto 1fr auto;gap:0.5rem;padding:1rem;background:#0b1220}
 textarea{resize:none;height:3rem}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,10 +8,13 @@
 <body>
   <header>
     <h1>LADA</h1>
-    <select id="provider">
+    <select id="orcProvider">
       <option>OpenAI</option><option>Ollama</option>
     </select>
     <input id="orcModel"  value="o4-mini"   placeholder="orchestrator model">
+    <select id="coderProvider">
+      <option>OpenAI</option><option>Ollama</option>
+    </select>
     <input id="coderModel" value="gpt-4.1-mini" placeholder="coder model">
     <select id="workers">
       <option>1</option>


### PR DESCRIPTION
## Summary
- allow choosing separate providers for the orchestrator and coder models
- query the coder model first to decide whether to orchestrate
- style orchestrator messages with a new color

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684ecb67fb5c83269149960f7b1ed3ea