### PR TITLE
Enable live orchestrator updates

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -27,6 +27,10 @@ socket.on('agent_result', a => {
   bubble(`[Agent ${a.id}] ${a.reply}`, 'ai', chatPane);
 });
 
+socket.on('chat_complete', data => {
+  handleChatResult(data);
+});
+
 async function loadHistory(){
   const r = await fetch("/api/history");
   const hist = await r.json();
@@ -73,22 +77,7 @@ function showPlan(planStr, round){
   }
 }
 
-/* ---------- CHAT ---------- */
-const chatInput  = document.getElementById("chatInput");
-async function sendChat(){
-  const msg = chatInput.value.trim(); if(!msg) return;
-  bubble(msg,"user",chatPane); chatInput.value="";
-
-  const data = await post("/api/chat",{
-    prompt:  msg,
-    orc_provider:   document.getElementById("orcProvider").value,
-    coder_provider: document.getElementById("coderProvider").value,
-    orchestrator_model: document.getElementById("orcModel").value,
-    coder_model:        document.getElementById("coderModel").value,
-    workers: parseInt(document.getElementById("workers").value,10),
-    orc_enabled: orcEnabled
-  });
-
+function handleChatResult(data){
   (data.plans||[]).forEach((p,i)=>{
     if(!shownPlans.has(i+1)){
       shownPlans.add(i+1);
@@ -119,6 +108,23 @@ async function sendChat(){
   if(data.orchestrator && data.orchestrator.reply){
     bubble(`[Orchestrator] ${data.orchestrator.reply}`,"orc",chatPane);
   }
+}
+
+/* ---------- CHAT ---------- */
+const chatInput  = document.getElementById("chatInput");
+async function sendChat(){
+  const msg = chatInput.value.trim(); if(!msg) return;
+  bubble(msg,"user",chatPane); chatInput.value="";
+
+  await post("/api/chat",{
+    prompt:  msg,
+    orc_provider:   document.getElementById("orcProvider").value,
+    coder_provider: document.getElementById("coderProvider").value,
+    orchestrator_model: document.getElementById("orcModel").value,
+    coder_model:        document.getElementById("coderModel").value,
+    workers: parseInt(document.getElementById("workers").value,10),
+    orc_enabled: orcEnabled
+  });
 }
 document.getElementById("sendChat").onclick = sendChat;
 chatInput.addEventListener("keydown", e => {


### PR DESCRIPTION
## Summary
- run chat processing in a background task so SocketIO messages are emitted while work is ongoing
- notify the frontend when chat processing completes
- listen for `chat_complete` events in the UI and handle results
- simplify frontend `sendChat` to fire the request and await SocketIO updates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68500be1fc74832689d6094f850f46c5