### PR TITLE
Enable live orchestrator updates via SocketIO

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -27,6 +27,39 @@ socket.on('agent_result', a => {
   bubble(`[Agent ${a.id}] ${a.reply}`, 'ai', chatPane);
 });
 
+socket.on('chat_done', data => {
+  (data.plans||[]).forEach((p,i)=>{
+    if(!shownPlans.has(i+1)){
+      shownPlans.add(i+1);
+      showPlan(p,i+1);
+    }
+  });
+  if(data.coder){
+    (data.coder.tool_runs||[]).forEach(t=>{
+      bubble(`[Coder] $ ${t.cmd}\n${t.result}`,'code',termPane);
+    });
+    if(data.coder.reply)
+      bubble(`[Coder] ${data.coder.reply}`,'ai',chatPane);
+  }
+  if(data.orchestrator){
+    (data.orchestrator.tool_runs||[]).forEach(t=>{
+      bubble(`[Orc] $ ${t.cmd}\n${t.result}`,'code',termPane);
+    });
+  }
+  (data.agents||[]).forEach(a=>{
+    const key = `${a.round}-${a.id}`;
+    if(shownAgents.has(key)) return;
+    shownAgents.add(key);
+    a.tool_runs.forEach(t=>{
+      bubble(`[A${a.id}] $ ${t.cmd}\n${t.result}`,'code',termPane);
+    });
+    bubble(`[Agent ${a.id}] ${a.reply}`,'ai',chatPane);
+  });
+  if(data.orchestrator && data.orchestrator.reply){
+    bubble(`[Orchestrator] ${data.orchestrator.reply}`,'orc',chatPane);
+  }
+});
+
 async function loadHistory(){
   const r = await fetch("/api/history");
   const hist = await r.json();
@@ -78,8 +111,7 @@ const chatInput  = document.getElementById("chatInput");
 async function sendChat(){
   const msg = chatInput.value.trim(); if(!msg) return;
   bubble(msg,"user",chatPane); chatInput.value="";
-
-  const data = await post("/api/chat",{
+  post("/api/chat",{
     prompt:  msg,
     orc_provider:   document.getElementById("orcProvider").value,
     coder_provider: document.getElementById("coderProvider").value,
@@ -88,37 +120,6 @@ async function sendChat(){
     workers: parseInt(document.getElementById("workers").value,10),
     orc_enabled: orcEnabled
   });
-
-  (data.plans||[]).forEach((p,i)=>{
-    if(!shownPlans.has(i+1)){
-      shownPlans.add(i+1);
-      showPlan(p,i+1);
-    }
-  });
-  if(data.coder){
-    (data.coder.tool_runs||[]).forEach(t=>{
-      bubble(`[Coder] $ ${t.cmd}\n${t.result}`,"code",termPane);
-    });
-    if(data.coder.reply)
-      bubble(`[Coder] ${data.coder.reply}`,"ai",chatPane);
-  }
-  if(data.orchestrator){
-    (data.orchestrator.tool_runs||[]).forEach(t=>{
-      bubble(`[Orc] $ ${t.cmd}\n${t.result}`,"code",termPane);
-    });
-  }
-  (data.agents||[]).forEach(a=>{
-    const key = `${a.round}-${a.id}`;
-    if(shownAgents.has(key)) return;
-    shownAgents.add(key);
-    a.tool_runs.forEach(t=>{
-      bubble(`[A${a.id}] $ ${t.cmd}\n${t.result}`,"code",termPane);
-    });
-    bubble(`[Agent ${a.id}] ${a.reply}`,"ai",chatPane);
-  });
-  if(data.orchestrator && data.orchestrator.reply){
-    bubble(`[Orchestrator] ${data.orchestrator.reply}`,"orc",chatPane);
-  }
 }
 document.getElementById("sendChat").onclick = sendChat;
 chatInput.addEventListener("keydown", e => {


### PR DESCRIPTION
## Summary
- run heavy chat logic in a background task
- send final results through new `chat_done` Socket.IO event
- modify frontend to rely on Socket.IO events and fire `/api/chat` asynchronously

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: running server only for manual checking)*

------
https://chatgpt.com/codex/tasks/task_e_68500be1fc74832689d6094f850f46c5