### PR TITLE
Add live updates for orchestrator actions

### DIFF
--- a/app.py
+++ b/app.py
@@ -349,6 +349,10 @@ def run_chat_logic(data: dict) -> dict:
                     t_runs.append({"cmd": label, "result": res})
                     msgs.append({"role": "assistant", "tool_calls": [a.model_dump(exclude_none=True)]})
                     msgs.append({"role": "tool", "tool_call_id": a.id, "name": label, "content": res})
+                    socketio.emit('agent_tool', {
+                        'id': aid, 'cmd': label, 'result': res, 'round': round_no
+                    })
+                    socketio.sleep(0)
                 continue
             msgs.append({"role": "assistant", "content": c.message.content})
             return {"id": aid, "reply": c.message.content, "tool_runs": t_runs, "messages": msgs, "round": round_no}
@@ -413,6 +417,8 @@ def run_chat_logic(data: dict) -> dict:
                     label = args.get("command") if call.function.name == "write_command" else call.function.name
                     orc_tool_runs.append({"cmd": label, "result": res})
                     orc_messages.append({"role": "tool", "tool_call_id": call.id, "name": label, "content": res})
+                    socketio.emit('orc_tool', {'cmd': label, 'result': res, 'round': round_no})
+                    socketio.sleep(0)
             continue
 
         text = choice.message.content or ""

--- a/static/app.js
+++ b/static/app.js
@@ -26,6 +26,12 @@ socket.on('agent_result', a => {
   });
   bubble(`[Agent ${a.id}] ${a.reply}`, 'ai', chatPane);
 });
+socket.on('orc_tool', t => {
+  bubble(`[Orc] $ ${t.cmd}\n${t.result}`, 'code', termPane);
+});
+socket.on('agent_tool', t => {
+  bubble(`[A${t.id}] $ ${t.cmd}\n${t.result}`, 'code', termPane);
+});
 socket.on('chat_done', d => {
   // coder section (if decision == "answer")
   if (d.coder) {

--- a/test_server.py
+++ b/test_server.py
@@ -1,0 +1,66 @@
+import json
+from types import SimpleNamespace
+import app
+from app import socketio, run_chat_logic
+
+class DummyToolCall:
+    def __init__(self, name, arguments, id="1"):
+        self.id = id
+        self.function = SimpleNamespace(name=name, arguments=arguments)
+    def model_dump(self, exclude_none=True):
+        return {"id": self.id, "function": {"name": self.function.name, "arguments": self.function.arguments}}
+
+class DummyChoice:
+    def __init__(self, content=None, tool_calls=None, finish_reason=None):
+        self.message = SimpleNamespace(content=content, tool_calls=tool_calls or [])
+        self.finish_reason = finish_reason
+
+class DummyResponse:
+    def __init__(self, choice):
+        self.choices = [choice]
+
+class DummyCompletions:
+    def __init__(self, responses):
+        self._responses = list(responses)
+    def create(self, *args, **kwargs):
+        return self._responses.pop(0)
+
+class DummyChat:
+    def __init__(self, responses):
+        self.completions = DummyCompletions(responses)
+
+class DummyClient:
+    def __init__(self, responses):
+        self.chat = DummyChat(responses)
+
+
+def test_orc_tool_event(monkeypatch):
+    router_resp = DummyResponse(DummyChoice(None, [DummyToolCall('route', json.dumps({'action':'hand_off'}))], 'tool_calls'))
+    orc_resp1 = DummyResponse(DummyChoice(None, [DummyToolCall('write_command', json.dumps({'command':'echo hi'}))], 'tool_calls'))
+    orc_resp2 = DummyResponse(DummyChoice("done", [], 'stop'))
+
+    coder_client = DummyClient([router_resp])
+    orc_client = DummyClient([orc_resp1, orc_resp2])
+
+    def fake_get_client(provider: str):
+        if provider == 'orc':
+            return orc_client
+        return coder_client
+
+    monkeypatch.setattr(app, 'get_client', fake_get_client)
+    test_client = socketio.test_client(app.app)
+
+    data = {
+        'prompt': 'hi',
+        'orc_provider': 'orc',
+        'coder_provider': 'coder',
+        'orchestrator_model': 'm',
+        'coder_model': 'c',
+        'workers': 1,
+        'orc_enabled': True,
+    }
+    run_chat_logic(data)
+
+    events = test_client.get_received()
+    names = [e['name'] for e in events]
+    assert 'orc_tool' in names


### PR DESCRIPTION
## Summary
- emit `orc_tool` and `agent_tool` events from `run_chat_logic`
- display orchestrator and agent tool output live in the frontend
- add regression test ensuring `orc_tool` is emitted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501271d804832694f55b605ba437bf