### PR TITLE
Implement real-time orchestrator updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,9 +216,7 @@ def history():
     """Return full conversation history."""
     return jsonify(HISTORY)
 
-@app.route("/api/chat", methods=["POST"])
-def chat():
-    data       = request.json
+def run_chat(data, sid=None):
     orc_provider   = data["orc_provider"]
     coder_provider = data["coder_provider"]
     orc_model  = data["orchestrator_model"]
@@ -351,24 +349,15 @@ def chat():
 
         add_history("assistant", final_answer)
         flush_history_to_disk()
-        if decision == "answer":
-            return jsonify(
-                {
-                    "plans": [],
-                    "coder": {"reply": final_answer, "tool_runs": coder_tool_runs},
-                    "orchestrator": None,
-                    "agents": [],
-                }
-            )
-        else:
-            return jsonify(
-                {
-                    "plans": [],
-                    "coder": None,
-                    "orchestrator": {"reply": final_answer, "tool_runs": coder_tool_runs},
-                    "agents": [],
-                }
-            )
+        result = {
+            "plans": [],
+            "coder": {"reply": final_answer, "tool_runs": coder_tool_runs} if decision == "answer" else None,
+            "orchestrator": None if decision == "answer" else {"reply": final_answer, "tool_runs": coder_tool_runs},
+            "agents": [],
+        }
+        if sid:
+            socketio.emit('chat_complete', result, to=sid)
+        return result
     # ----- ask orchestrator for a plan -----
     planner_sys = (
         # "You are an orchestrator. Coder agents are independent and share no "
@@ -477,7 +466,7 @@ def chat():
                     except Exception:
                         plan = {"agents": 0, "tasks": []}
                     all_plans.append(plan_text)
-                    socketio.emit('plan', {'plan': plan_text, 'round': round_no})
+                    socketio.emit('plan', {'plan': plan_text, 'round': round_no}, to=sid)
                     if plan.get("tasks") and plan.get("agents", 0) > 0:
                         num_agents = min(int(plan.get("agents", 1)), workers)
                         agent_tasks = {i: [] for i in range(1, num_agents + 1)}
@@ -496,7 +485,7 @@ def chat():
                             socketio.emit('agent_result', {
                                 'id': r['id'], 'reply': r['reply'],
                                 'tool_runs': r['tool_runs'], 'round': r['round']
-                            })
+                            }, to=sid)
                         summary = "\n".join(f"Agent {r['id']} result: {r['reply']}" for r in results)
                         orc_messages.append({"role": "user", "content": summary})
                     continue
@@ -515,7 +504,7 @@ def chat():
 
         if isinstance(plan, dict) and "tasks" in plan and "agents" in plan:
             all_plans.append(text)
-            socketio.emit('plan', {'plan': text, 'round': round_no})
+            socketio.emit('plan', {'plan': text, 'round': round_no}, to=sid)
             if plan.get("tasks") and plan.get("agents", 0) > 0:
                 num_agents = min(int(plan.get("agents", 1)), workers)
                 agent_tasks = {i: [] for i in range(1, num_agents + 1)}
@@ -534,7 +523,7 @@ def chat():
                     socketio.emit('agent_result', {
                         'id': r['id'], 'reply': r['reply'],
                         'tool_runs': r['tool_runs'], 'round': r['round']
-                    })
+                    }, to=sid)
                 summary = "\n".join(f"Agent {r['id']} result: {r['reply']}" for r in results)
                 orc_messages.append({"role": "user", "content": summary})
                 continue
@@ -554,11 +543,21 @@ def chat():
     #     json.dump(HISTORY, f, ensure_ascii=False, indent=2)
     flush_history_to_disk()
 
-    return jsonify({
+    result = {
         "plans": all_plans,
         "orchestrator": {"reply": final_reply, "tool_runs": orc_tool_runs},
         "agents": [{"id": a["id"], "reply": a["reply"], "tool_runs": a["tool_runs"], "round": a["round"]} for a in all_agents]
-    })
+    }
+    if sid:
+        socketio.emit('chat_complete', result, to=sid)
+    return result
+
+@app.route("/api/chat", methods=["POST"])
+def chat():
+    data = request.json
+    sid = data.get("sid")
+    socketio.start_background_task(run_chat, data, sid)
+    return jsonify({"status": "processing"})
 
 @app.route("/api/command", methods=["POST"])
 def terminal():

--- a/static/app.js
+++ b/static/app.js
@@ -27,6 +27,32 @@ socket.on('agent_result', a => {
   bubble(`[Agent ${a.id}] ${a.reply}`, 'ai', chatPane);
 });
 
+socket.on('chat_complete', data => {
+  if(data.coder){
+    (data.coder.tool_runs||[]).forEach(t => {
+      bubble(`[Coder] $ ${t.cmd}\n${t.result}`, 'code', termPane);
+    });
+    if(data.coder.reply)
+      bubble(`[Coder] ${data.coder.reply}`, 'ai', chatPane);
+  }
+  if(data.orchestrator){
+    (data.orchestrator.tool_runs||[]).forEach(t => {
+      bubble(`[Orc] $ ${t.cmd}\n${t.result}`, 'code', termPane);
+    });
+    if(data.orchestrator.reply)
+      bubble(`[Orchestrator] ${data.orchestrator.reply}`, 'orc', chatPane);
+  }
+  (data.agents||[]).forEach(a => {
+    const key = `${a.round}-${a.id}`;
+    if(shownAgents.has(key)) return;
+    shownAgents.add(key);
+    a.tool_runs.forEach(t => {
+      bubble(`[A${a.id}] $ ${t.cmd}\n${t.result}`, 'code', termPane);
+    });
+    bubble(`[Agent ${a.id}] ${a.reply}`, 'ai', chatPane);
+  });
+});
+
 async function loadHistory(){
   const r = await fetch("/api/history");
   const hist = await r.json();
@@ -79,46 +105,16 @@ async function sendChat(){
   const msg = chatInput.value.trim(); if(!msg) return;
   bubble(msg,"user",chatPane); chatInput.value="";
 
-  const data = await post("/api/chat",{
+  await post("/api/chat",{
     prompt:  msg,
     orc_provider:   document.getElementById("orcProvider").value,
     coder_provider: document.getElementById("coderProvider").value,
     orchestrator_model: document.getElementById("orcModel").value,
     coder_model:        document.getElementById("coderModel").value,
     workers: parseInt(document.getElementById("workers").value,10),
-    orc_enabled: orcEnabled
+    orc_enabled: orcEnabled,
+    sid: socket.id
   });
-
-  (data.plans||[]).forEach((p,i)=>{
-    if(!shownPlans.has(i+1)){
-      shownPlans.add(i+1);
-      showPlan(p,i+1);
-    }
-  });
-  if(data.coder){
-    (data.coder.tool_runs||[]).forEach(t=>{
-      bubble(`[Coder] $ ${t.cmd}\n${t.result}`,"code",termPane);
-    });
-    if(data.coder.reply)
-      bubble(`[Coder] ${data.coder.reply}`,"ai",chatPane);
-  }
-  if(data.orchestrator){
-    (data.orchestrator.tool_runs||[]).forEach(t=>{
-      bubble(`[Orc] $ ${t.cmd}\n${t.result}`,"code",termPane);
-    });
-  }
-  (data.agents||[]).forEach(a=>{
-    const key = `${a.round}-${a.id}`;
-    if(shownAgents.has(key)) return;
-    shownAgents.add(key);
-    a.tool_runs.forEach(t=>{
-      bubble(`[A${a.id}] $ ${t.cmd}\n${t.result}`,"code",termPane);
-    });
-    bubble(`[Agent ${a.id}] ${a.reply}`,"ai",chatPane);
-  });
-  if(data.orchestrator && data.orchestrator.reply){
-    bubble(`[Orchestrator] ${data.orchestrator.reply}`,"orc",chatPane);
-  }
 }
 document.getElementById("sendChat").onclick = sendChat;
 chatInput.addEventListener("keydown", e => {


### PR DESCRIPTION
## Summary
- run orchestrator logic in a background task
- target socket.io messages to the requesting client
- show final results through new `chat_complete` event
- update frontend to send socket id and handle live updates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6850139181848326a9511f8479f88f9e