### PR TITLE
Fix socket update delivery

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -27,6 +27,32 @@ socket.on('agent_result', a => {
   bubble(`[Agent ${a.id}] ${a.reply}`, 'ai', chatPane);
 });
 
+socket.on('chat_complete', data => {
+  if(data.coder){
+    (data.coder.tool_runs||[]).forEach(t => {
+      bubble(`[Coder] $ ${t.cmd}\n${t.result}`, 'code', termPane);
+    });
+    if(data.coder.reply)
+      bubble(`[Coder] ${data.coder.reply}`, 'ai', chatPane);
+  }
+  if(data.orchestrator){
+    (data.orchestrator.tool_runs||[]).forEach(t => {
+      bubble(`[Orc] $ ${t.cmd}\n${t.result}`, 'code', termPane);
+    });
+    if(data.orchestrator.reply)
+      bubble(`[Orchestrator] ${data.orchestrator.reply}`, 'orc', chatPane);
+  }
+  (data.agents||[]).forEach(a => {
+    const key = `${a.round}-${a.id}`;
+    if(shownAgents.has(key)) return;
+    shownAgents.add(key);
+    a.tool_runs.forEach(t => {
+      bubble(`[A${a.id}] $ ${t.cmd}\n${t.result}`, 'code', termPane);
+    });
+    bubble(`[Agent ${a.id}] ${a.reply}`, 'ai', chatPane);
+  });
+});
+
 async function loadHistory(){
   const r = await fetch("/api/history");
   const hist = await r.json();
@@ -73,22 +99,7 @@ function showPlan(planStr, round){
   }
 }
 
-/* ---------- CHAT ---------- */
-const chatInput  = document.getElementById("chatInput");
-async function sendChat(){
-  const msg = chatInput.value.trim(); if(!msg) return;
-  bubble(msg,"user",chatPane); chatInput.value="";
-
-  const data = await post("/api/chat",{
-    prompt:  msg,
-    orc_provider:   document.getElementById("orcProvider").value,
-    coder_provider: document.getElementById("coderProvider").value,
-    orchestrator_model: document.getElementById("orcModel").value,
-    coder_model:        document.getElementById("coderModel").value,
-    workers: parseInt(document.getElementById("workers").value,10),
-    orc_enabled: orcEnabled
-  });
-
+function processResult(data){
   (data.plans||[]).forEach((p,i)=>{
     if(!shownPlans.has(i+1)){
       shownPlans.add(i+1);
@@ -97,27 +108,47 @@ async function sendChat(){
   });
   if(data.coder){
     (data.coder.tool_runs||[]).forEach(t=>{
-      bubble(`[Coder] $ ${t.cmd}\n${t.result}`,"code",termPane);
+      bubble(`[Coder] $ ${t.cmd}\n${t.result}`,'code',termPane);
     });
     if(data.coder.reply)
-      bubble(`[Coder] ${data.coder.reply}`,"ai",chatPane);
+      bubble(`[Coder] ${data.coder.reply}`,'ai',chatPane);
   }
   if(data.orchestrator){
     (data.orchestrator.tool_runs||[]).forEach(t=>{
-      bubble(`[Orc] $ ${t.cmd}\n${t.result}`,"code",termPane);
+      bubble(`[Orc] $ ${t.cmd}\n${t.result}`,'code',termPane);
     });
+    if(data.orchestrator.reply)
+      bubble(`[Orchestrator] ${data.orchestrator.reply}`,'orc',chatPane);
   }
   (data.agents||[]).forEach(a=>{
     const key = `${a.round}-${a.id}`;
     if(shownAgents.has(key)) return;
     shownAgents.add(key);
     a.tool_runs.forEach(t=>{
-      bubble(`[A${a.id}] $ ${t.cmd}\n${t.result}`,"code",termPane);
+      bubble(`[A${a.id}] $ ${t.cmd}\n${t.result}`,'code',termPane);
     });
-    bubble(`[Agent ${a.id}] ${a.reply}`,"ai",chatPane);
+    bubble(`[Agent ${a.id}] ${a.reply}`,'ai',chatPane);
   });
-  if(data.orchestrator && data.orchestrator.reply){
-    bubble(`[Orchestrator] ${data.orchestrator.reply}`,"orc",chatPane);
+}
+
+/* ---------- CHAT ---------- */
+const chatInput  = document.getElementById("chatInput");
+async function sendChat(){
+  const msg = chatInput.value.trim(); if(!msg) return;
+  bubble(msg,"user",chatPane); chatInput.value="";
+
+  const res = await post("/api/chat",{
+    prompt:  msg,
+    orc_provider:   document.getElementById("orcProvider").value,
+    coder_provider: document.getElementById("coderProvider").value,
+    orchestrator_model: document.getElementById("orcModel").value,
+    coder_model:        document.getElementById("coderModel").value,
+    workers: parseInt(document.getElementById("workers").value,10),
+    orc_enabled: orcEnabled,
+    sid: socket.id
+  });
+  if(res.status !== 'processing'){
+    processResult(res);
   }
 }
 document.getElementById("sendChat").onclick = sendChat;


### PR DESCRIPTION
## Summary
- broadcast socket events if sid missing so chat updates always deliver
- provide synchronous fallback for `/api/chat`
- handle direct responses client-side

## Testing
- `python -m py_compile app.py`
- ❌ `curl -X POST http://127.0.0.1:5000/api/chat ...` *(fails: APIConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_6850139181848326a9511f8479f88f9e