### PR TITLE
Add settings menu with API token and terminal toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,9 +46,11 @@ def flush_history_to_disk() -> None:
     with open(HISTORY_FILE, "w", encoding="utf-8") as f:
         json.dump(HISTORY, f, ensure_ascii=False, indent=2)
 # ---------- helpers ---------- #
-def get_client(provider: str):
+def get_client(provider: str, token: str | None = None):
     if provider.lower() == "ollama":
         return OpenAI(base_url="http://localhost:11434/v1", api_key="ollama")
+    if token:
+        return OpenAI(api_key=token)
     return OpenAI()
 
 ROOT_DIR = pathlib.Path.cwd().resolve()
@@ -225,10 +227,11 @@ def chat():
     coder_model= data["coder_model"]
     workers    = int(data.get("workers", 2))
     orc_enabled = data.get("orc_enabled", True)
+    api_token   = data.get("api_token")
     user_msg   = data["prompt"]
 
-    orc_client   = get_client(orc_provider)
-    coder_client = get_client(coder_provider)
+    orc_client   = get_client(orc_provider, api_token)
+    coder_client = get_client(coder_provider, api_token)
 
 
     # HISTORY.append({"role": "user", "content": user_msg})

--- a/static/app.js
+++ b/static/app.js
@@ -10,6 +10,37 @@ orcToggle.onclick = () => {
   orcToggle.textContent = `Orchestrator ${orcEnabled ? 'ON' : 'OFF'}`;
 };
 
+/* ---------- SETTINGS ---------- */
+const settingsBtn   = document.getElementById("settingsBtn");
+const settingsMenu  = document.getElementById("settingsMenu");
+const apiTokenField = document.getElementById("apiTokenField");
+const termToggle    = document.getElementById("termToggle");
+
+let apiToken = localStorage.getItem("apiToken") || "";
+apiTokenField.value = apiToken;
+apiTokenField.addEventListener("input", () => {
+  apiToken = apiTokenField.value.trim();
+  localStorage.setItem("apiToken", apiToken);
+});
+
+let showTerminal = localStorage.getItem("showTerminal");
+if(showTerminal === null) showTerminal = "true";
+showTerminal = showTerminal === "true";
+termToggle.checked = showTerminal;
+function updateTerminalVisibility(){
+  const show = termToggle.checked;
+  termPane.style.display = show ? "" : "none";
+  document.getElementById("cmdInput").style.display = show ? "" : "none";
+  document.getElementById("sendCmd").style.display = show ? "" : "none";
+  localStorage.setItem("showTerminal", show);
+}
+termToggle.onchange = updateTerminalVisibility;
+updateTerminalVisibility();
+
+settingsBtn.onclick = () => {
+  settingsMenu.style.display = settingsMenu.style.display === "block" ? "none" : "block";
+};
+
 socket.on('plan', d => {
   if(!shownPlans.has(d.round)){
     shownPlans.add(d.round);
@@ -43,6 +74,7 @@ async function loadHistory(){
 loadHistory();
 
 async function post(url, body){
+  if(apiToken) body.api_token = apiToken;
   const r = await fetch(url,{
       method:"POST",
       headers:{ "Content-Type":"application/json" },

--- a/static/style.css
+++ b/static/style.css
@@ -13,7 +13,7 @@ body{
   grid-template-rows:auto minmax(0,1fr) auto;
   background:linear-gradient(135deg,var(--bg1),var(--bg2)); color:var(--msg); font-family:system-ui;
 }
-header{display:flex;gap:1rem;align-items:center;padding:0.5rem 1rem}
+header{display:flex;gap:1rem;align-items:center;padding:0.5rem 1rem;position:relative}
 h1{margin:0;font-size:1.3rem;color:var(--accent)}
 input,select,textarea,button{border:none;outline:none;border-radius:6px;padding:.4rem .6rem;font:inherit}
 button{background:var(--accent);color:#000;cursor:pointer}
@@ -52,4 +52,17 @@ main{
 #orcToggle{margin-bottom:0.5rem}
 footer{display:grid;grid-template-columns:1fr auto 1fr auto;gap:0.5rem;padding:1rem;background:#0b1220}
 textarea{resize:none;height:3rem}
+
+#settingsMenu{
+  position:absolute;
+  right:1rem;
+  top:calc(100% + .5rem);
+  background:var(--bg2);
+  padding:1rem;
+  border-radius:8px;
+  display:none;
+  flex-direction:column;
+  gap:.5rem;
+}
+#settingsMenu label{display:block}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,11 @@
       <option>4</option>
     </select>
     <button id="orcToggle">Orchestrator ON</button>
+    <button id="settingsBtn" style="margin-left:auto">⚙️</button>
+    <div id="settingsMenu">
+      <label>API Token <input id="apiTokenField" type="password" placeholder="sk-..."></label>
+      <label><input type="checkbox" id="termToggle" checked> Show Terminal</label>
+    </div>
   </header>
 
   <main id="panes">


### PR DESCRIPTION
## Summary
- add flexible `get_client` for optional API token
- handle custom API token in chat endpoint
- implement settings UI with API token field and terminal visibility toggle
- wire up settings logic in JS
- style settings menu

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685020a524848326b8f28c162ff7debb